### PR TITLE
Add Flask web interface for schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # SchoolSchedule
+
+This project provides tools to view and modify school pick‑up schedules.
+
+## Command line usage
+
+Run the existing script to print a text table or generate static HTML:
+
+```bash
+python PickupSechdule2.py        # text table output
+python PickupSechdule2.py --html # write pickup_schedule.html
+```
+
+## Web interface
+
+A basic Flask app offers an interactive table for editing the schedule.
+
+### Run the web app
+
+```bash
+pip install flask prettytable
+python app.py
+```
+
+Open <http://127.0.0.1:5000> in a browser and use the drop‑down menus to set
+status values for each day. Press **Save** to update the schedule in memory.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,39 @@
+from flask import Flask, render_template, request, redirect, url_for
+
+from PickupSechdule2 import (
+    STATUS_DEFINITIONS,
+    SCHEDULE_DATA,
+    get_week_dates,
+    DAYS,
+)
+
+app = Flask(__name__)
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    """Render the schedule table and handle updates from the form."""
+    if request.method == 'POST':
+        for w, week in enumerate(SCHEDULE_DATA):
+            for key in ['pick_up_1', 'pick_up_2']:
+                for d, _ in enumerate(DAYS):
+                    field = f'w{w}_{key}_{d}'
+                    value = request.form.get(field)
+                    if value is not None:
+                        try:
+                            week[key][d] = int(value)
+                        except ValueError:
+                            pass
+        return redirect(url_for('index'))
+
+    return render_template(
+        'index.html',
+        schedule=SCHEDULE_DATA,
+        status_defs=STATUS_DEFINITIONS,
+        days=DAYS,
+        get_week_dates=get_week_dates,
+    )
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Pickup Schedule</title>
+  <style>
+    table { border-collapse: collapse; margin-bottom: 1em; }
+    th, td { border: 1px solid #ccc; padding: 0.5em; text-align: center; }
+    th { background: #d9ead3; }
+    tr.date-row { background: #cfe2f3; font-weight: bold; }
+    td.label-cell { font-weight: bold; text-align: left; }
+  </style>
+</head>
+<body>
+<h1>Pickup Schedule</h1>
+<form method="post">
+{% for w, week in enumerate(schedule) %}
+  <table>
+    <tr class="date-row">
+      <td class="label-cell">Week {{ week.week_start.strftime('%W') }}</td>
+      {% for date in get_week_dates(week.week_start) %}
+        <th>{{ date }}</th>
+      {% endfor %}
+    </tr>
+    {% for key, label in [('pick_up_1', 'Pick AM'), ('pick_up_2', 'Pick PM')] %}
+      <tr>
+        <td class="label-cell">{{ label }}</td>
+        {% for d in range(days|length) %}
+          <td>
+            <select name="w{{ w }}_{{ key }}_{{ d }}">
+              {% for code, info in status_defs.items() %}
+                <option value="{{ code }}" {% if week[key][d] == code %}selected{% endif %}>{{ info.text }}</option>
+              {% endfor %}
+            </select>
+          </td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+  </table>
+{% endfor %}
+  <button type="submit">Save</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `app.py` Flask server serving schedule with dropdown cells
- include Jinja template for schedule table editing
- document web app usage and add `.gitignore`

## Testing
- `python -m py_compile PickupSechdule2.py app.py`
- `pip install flask` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install prettytable` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb0bad948322b04f7eb7f73c4d51