### PR TITLE
Replace dropdowns with clickable status icons

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,9 +15,10 @@ app = Flask(__name__)
 def index():
     """Render the schedule table and handle updates from the form."""
     if request.method == 'POST':
+        # Values now come from hidden inputs populated by JS
         for w, week in enumerate(SCHEDULE_DATA):
             for key in ['pick_up_1', 'pick_up_2']:
-                for d, _ in enumerate(DAYS):
+                for d in range(len(DAYS)):
                     field = f'w{w}_{key}_{d}'
                     value = request.form.get(field)
                     if value is not None:

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
     th { background: #d9ead3; }
     tr.date-row { background: #cfe2f3; font-weight: bold; }
     td.label-cell { font-weight: bold; text-align: left; }
+    .status-icon { cursor: pointer; }
   </style>
 </head>
 <body>
@@ -27,11 +28,8 @@
         <td class="label-cell">{{ label }}</td>
         {% for d in range(days|length) %}
           <td>
-            <select name="w{{ w }}_{{ key }}_{{ d }}">
-              {% for code, info in status_defs.items() %}
-                <option value="{{ code }}" {% if week[key][d] == code %}selected{% endif %}>{{ info.text }}</option>
-              {% endfor %}
-            </select>
+            <input type="hidden" id="w{{ w }}_{{ key }}_{{ d }}" name="w{{ w }}_{{ key }}_{{ d }}" value="{{ week[key][d] }}">
+            <span class="status-icon" data-input="w{{ w }}_{{ key }}_{{ d }}">{{ status_defs[week[key][d]].html|safe }}</span>
           </td>
         {% endfor %}
       </tr>
@@ -40,5 +38,18 @@
 {% endfor %}
   <button type="submit">Save</button>
 </form>
+<script>
+  const statusDefs = {{ status_defs | tojson }};
+  const codes = Object.keys(statusDefs);
+  document.querySelectorAll('.status-icon').forEach(function(el){
+    el.addEventListener('click', function(){
+      const input = document.getElementById(el.dataset.input);
+      const idx = codes.indexOf(input.value);
+      const next = codes[(idx + 1) % codes.length];
+      input.value = next;
+      el.innerHTML = statusDefs[next].html;
+    });
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- swap `<select>` fields for clickable status icons backed by hidden inputs
- cycle through `status_defs` values via JavaScript and save updates
- read new hidden inputs during form submission

## Testing
- `python -m py_compile app.py PickupSechdule2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6f18a73d083229b7000177ddbb349