### PR TITLE
Fix undefined enumerate in Jinja template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,8 @@
 <body>
 <h1>Pickup Schedule</h1>
 <form method="post">
-{% for w, week in enumerate(schedule) %}
+{% for week in schedule %}
+  {% set w = loop.index0 %}
   <table>
     <tr class="date-row">
       <td class="label-cell">Week {{ week.week_start.strftime('%W') }}</td>


### PR DESCRIPTION
## Summary
- Avoid Jinja UndefinedError by removing Python `enumerate` call from `templates/index.html`
- Use Jinja loop index to generate stable element IDs

## Testing
- `python -m py_compile app.py PickupSechdule2.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f3e12f708322ab66c86f3dee0ef5