### PR TITLE
Refactor schedule layout with responsive flexbox

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,63 @@
+body { font-family: 'Roboto', sans-serif; }
+
+.week-block { margin-bottom: 1em; }
+
+.week-grid { display: flex; flex-direction: column; }
+
+.row { display: flex; }
+
+.label-cell {
+  font-weight: bold;
+  text-align: left;
+  flex: 0 0 100px;
+  border: 1px solid #ccc;
+  padding: 0.5em;
+}
+
+.cell {
+  flex: 1;
+  border: 1px solid #ccc;
+  padding: 0.5em;
+  text-align: center;
+}
+
+.header-row .label-cell,
+.header-row .cell { background: #d9ead3; }
+
+.row:nth-child(even) .label-cell,
+.row:nth-child(even) .cell { background: #f9f9f9; }
+
+.row:hover .label-cell,
+.row:hover .cell { background: #e3f2fd; }
+
+.cell:hover { background: #fffbdd; }
+
+.parent-container { display: flex; }
+
+.parent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.parent-label { font-size: 0.7em; margin-bottom: 2px; }
+
+.status-icon { cursor: pointer; }
+
+.status-tick { color: #fff; background: green; font-weight: bold; padding: 2px 4px; border-radius: 3px; }
+.status-cross { color: red; font-weight: bold; }
+.status-travel { color: blue; font-style: italic; }
+.status-office { color: gray; }
+.status-unknown { color: purple; font-weight: bold; }
+
+ul.legend { list-style: none; padding: 0; }
+ul.legend li { margin-bottom: 5px; }
+ul.legend span { display: inline-block; min-width: 20px; text-align: center; margin-right: 10px; }
+
+button { font-family: 'Roboto', sans-serif; }
+
+@media (max-width: 600px) {
+  .row { flex-direction: column; }
+  .label-cell { flex: 1; text-align: center; }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,27 +4,7 @@
   <meta charset="utf-8">
   <title>Pickup Schedule</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
-  <style>
-    body { font-family: 'Roboto', sans-serif; }
-    table { border-collapse: collapse; margin-bottom: 1em; }
-    th, td { border: 1px solid #ccc; padding: 0.5em; text-align: center; }
-    button { font-family: 'Roboto', sans-serif; }
-    th { background: #d9ead3; }
-    tr.date-row { background: #cfe2f3; font-weight: bold; }
-    td.label-cell { font-weight: bold; text-align: left; }
-    .status-icon { cursor: pointer; }
-    .parent-container { display: flex; }
-    .parent { flex: 1; display: flex; flex-direction: column; align-items: center; }
-    .parent-label { font-size: 0.7em; margin-bottom: 2px; }
-    ul.legend { list-style: none; padding: 0; }
-    ul.legend li { margin-bottom: 5px; }
-    ul.legend span { display: inline-block; min-width: 20px; text-align: center; margin-right: 10px; }
-    .status-tick { color: #fff; background: green; font-weight: bold; padding: 2px 4px; border-radius: 3px; }
-    .status-cross { color: red; font-weight: bold; }
-    .status-travel { color: blue; font-style: italic; }
-    .status-office { color: gray; }
-    .status-unknown { color: purple; font-weight: bold; }
-  </style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
 <h1>Pickup Schedule</h1>
@@ -32,36 +12,36 @@
 {% for week in schedule %}
   {% set w = loop.index0 %}
   <div class="week-block">
-  <button type="button" class="remove-week" data-week="{{ w }}">Remove Week</button>
-  <table>
-    <tr class="date-row">
-      <td class="label-cell">Week {{ week.week_start.strftime('%W') }}</td>
-      {% for date in get_week_dates(week.week_start) %}
-        <th>{{ date }}</th>
-      {% endfor %}
-    </tr>
-    {% for key, label in [('pick_up_1', 'Pick AM'), ('pick_up_2', 'Pick PM')] %}
-      <tr>
-        <td class="label-cell">{{ label }}</td>
-        {% for d in range(days|length) %}
-          <td>
-            <div class="parent-container">
-              <div class="parent">
-                <span class="parent-label">M</span>
-                <input type="hidden" id="w{{ w }}_{{ key }}_m{{ d }}" name="w{{ w }}_{{ key }}_m{{ d }}" value="{{ week[key][d][0] }}">
-                <span class="status-icon" data-input="w{{ w }}_{{ key }}_m{{ d }}">{{ status_defs[week[key][d][0]].html|safe }}</span>
-              </div>
-              <div class="parent">
-                <span class="parent-label">F</span>
-                <input type="hidden" id="w{{ w }}_{{ key }}_f{{ d }}" name="w{{ w }}_{{ key }}_f{{ d }}" value="{{ week[key][d][1] }}">
-                <span class="status-icon" data-input="w{{ w }}_{{ key }}_f{{ d }}">{{ status_defs[week[key][d][1]].html|safe }}</span>
+    <button type="button" class="remove-week" data-week="{{ w }}">Remove Week</button>
+    <div class="week-grid">
+      <div class="row header-row">
+        <div class="label-cell">Week {{ week.week_start.strftime('%W') }}</div>
+        {% for date in get_week_dates(week.week_start) %}
+          <div class="cell">{{ date }}</div>
+        {% endfor %}
+      </div>
+      {% for key, label in [('pick_up_1', 'Pick AM'), ('pick_up_2', 'Pick PM')] %}
+        <div class="row">
+          <div class="label-cell">{{ label }}</div>
+          {% for d in range(days|length) %}
+            <div class="cell">
+              <div class="parent-container">
+                <div class="parent">
+                  <span class="parent-label">M</span>
+                  <input type="hidden" id="w{{ w }}_{{ key }}_m{{ d }}" name="w{{ w }}_{{ key }}_m{{ d }}" value="{{ week[key][d][0] }}">
+                  <span class="status-icon" data-input="w{{ w }}_{{ key }}_m{{ d }}">{{ status_defs[week[key][d][0]].html|safe }}</span>
+                </div>
+                <div class="parent">
+                  <span class="parent-label">F</span>
+                  <input type="hidden" id="w{{ w }}_{{ key }}_f{{ d }}" name="w{{ w }}_{{ key }}_f{{ d }}" value="{{ week[key][d][1] }}">
+                  <span class="status-icon" data-input="w{{ w }}_{{ key }}_f{{ d }}">{{ status_defs[week[key][d][1]].html|safe }}</span>
+                </div>
               </div>
             </div>
-          </td>
-        {% endfor %}
-      </tr>
-    {% endfor %}
-  </table>
+          {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
   </div>
 {% endfor %}
 </form>


### PR DESCRIPTION
## Summary
- Replace table-based schedule with responsive flexbox grid
- Collapse columns into stacked rows on narrow screens via media queries
- Add alternating row backgrounds and hover effects for easier tracking
- Move all styling into `static/styles.css`

## Testing
- `python -m py_compile app.py PickupSechdule2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a72908680c8322849f66a8eec0d242